### PR TITLE
Implementar firestore 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.google)
 }
 
 android {
@@ -47,6 +48,8 @@ dependencies {
     implementation (libs.gson)
     implementation(libs.room.runtime)
     ksp(libs.room.ksp)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.firestore)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/alfsuace/exaddfebrero/MainActivity.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/MainActivity.kt
@@ -101,6 +101,7 @@ class MainActivity : AppCompatActivity() {
             Album(id = "A2","1 seta" ,mockMushrooms2,stickers = listOf(mockStickers[2]))
         )
         val fs= FirestoreProvider.provideFirestore()
+        val guardarMock=AlbumRemoteDataSource(fs)
         val repo = AlbumDataRepositoryFirestore(AlbumRemoteDataSource(fs))
         val editUseCase = EditAlbumUseCase(repo)
 
@@ -112,6 +113,10 @@ class MainActivity : AppCompatActivity() {
         )
 
         GlobalScope.launch (Dispatchers.IO){
+
+            guardarMock.saveStickers(mockStickers)
+            guardarMock.saveMushrooms(mockMushrooms)
+
             Log.d("@dev", "lista base: ${repo.getAlbums()}")
             repo.saveAlbum(albumCreated)
             Log.d("@dev", repo.getAlbums().toString())

--- a/app/src/main/java/com/alfsuace/exaddfebrero/MainActivity.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/MainActivity.kt
@@ -3,11 +3,14 @@ package com.alfsuace.exaddfebrero
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import com.alfsuace.exaddfebrero.app.FirestoreProvider
 import com.alfsuace.exaddfebrero.app.RoomProvider
 import com.alfsuace.exaddfebrero.domain.Album
 import com.alfsuace.exaddfebrero.domain.EditAlbumUseCase
 import com.alfsuace.exaddfebrero.domain.Mushroom
 import com.alfsuace.exaddfebrero.domain.Sticker
+import com.alfsuace.exaddfebrero.firestore.data.AlbumDataRepositoryFirestore
+import com.alfsuace.exaddfebrero.firestore.data.remote.AlbumRemoteDataSource
 import com.alfsuace.exaddfebrero.room.data.AlbumDataRepository
 import com.alfsuace.exaddfebrero.room.data.local.AlbumLocalDbDataSource
 import kotlinx.coroutines.Dispatchers
@@ -18,8 +21,8 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        executeRoom()
+        //executeRoom()
+        executeFirestore()
     }
 
     private fun executeRoom() {
@@ -73,6 +76,56 @@ class MainActivity : AppCompatActivity() {
             Log.d("@dev", albumEdited.toString())
 
 
+        }
+    }
+
+    private fun executeFirestore(){
+
+        val mockMushrooms = listOf(
+            Mushroom(id = "1", name = "Boletus edulis", family = "Boletaceae", description = "Seta comestible muy apreciada."),
+            Mushroom(id = "2", name = "Amanita muscaria", family = "Amanitaceae", description = "Tóxica, de color rojo con puntos blancos."),
+            Mushroom(id = "3", name = "Agaricus campestris", family = "Agaricaceae", description = "Conocida como champiñón silvestre."),
+            Mushroom(id = "4", name = "Cantharellus cibarius", family = "Cantharellaceae", description = "También conocida como rebozuelo.")
+        )
+        val mockMushrooms2 = listOf(
+            Mushroom(id = "1", name = "Boletus edulis", family = "Boletaceae", description = "Seta comestible muy apreciada."),
+            Mushroom(id = "2", name = "Amanita muscaria", family = "Amanitaceae", description = "Tóxica, de color rojo con puntos blancos.")
+        )
+        val mockStickers = listOf(
+            Sticker(id = "101",mockMushrooms[0] ,photo = "https://example.com/photo1.jpg", latitude = "40.4168", longitude = "-3.7038", dateTime = "2025-02-12 14:30"),
+            Sticker(id = "102", mockMushrooms[1], photo = "https://example.com/photo2.jpg", latitude = "41.4036", longitude = "2.1744", dateTime = "2025-02-11 10:15"),
+            Sticker(id = "103", mockMushrooms[2], photo = "https://example.com/photo3.jpg", latitude = "39.4699", longitude = "-0.3763", dateTime = "2025-02-10 08:45")
+        )
+        val mockAlbums = listOf(
+            Album(id = "A1","2 setas", mockMushrooms,stickers = listOf(mockStickers[0], mockStickers[1])),
+            Album(id = "A2","1 seta" ,mockMushrooms2,stickers = listOf(mockStickers[2]))
+        )
+        val fs= FirestoreProvider.provideFirestore()
+        val repo = AlbumDataRepositoryFirestore(AlbumRemoteDataSource(fs))
+        val editUseCase = EditAlbumUseCase(repo)
+
+        val albumCreated= Album(
+            id = "103",
+            "creado",
+            mockMushrooms2,
+            stickers = listOf(mockStickers[1], mockStickers[2])
+        )
+
+        GlobalScope.launch (Dispatchers.IO){
+            Log.d("@dev", "lista base: ${repo.getAlbums()}")
+            repo.saveAlbum(albumCreated)
+            Log.d("@dev", repo.getAlbums().toString())
+            repo.deleteAlbum(albumCreated)
+            Log.d("@dev", repo.getAlbums().toString())
+            //ELIMINAR CROMO
+            repo.saveAlbum(albumCreated)
+            val album = repo.getAlbumById(albumCreated.id)
+            Log.d("@dev", album.toString())
+            album?.let {
+                editUseCase.invoke(album, mockStickers[1])
+            }
+            val albumEdited = repo.getAlbumById(albumCreated.id)
+            Log.d("@dev", albumEdited.toString())
         }
     }
 }

--- a/app/src/main/java/com/alfsuace/exaddfebrero/MainActivity.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/MainActivity.kt
@@ -21,7 +21,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        //executeRoom()
+        executeRoom()
         executeFirestore()
     }
 

--- a/app/src/main/java/com/alfsuace/exaddfebrero/app/FirestoreProvider.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/app/FirestoreProvider.kt
@@ -1,0 +1,11 @@
+package com.alfsuace.exaddfebrero.app
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.firestore
+
+object FirestoreProvider {
+    fun provideFirestore(): FirebaseFirestore {
+        return Firebase.firestore
+    }
+}

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/AlbumDataRepositoryFirestore.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/AlbumDataRepositoryFirestore.kt
@@ -1,0 +1,27 @@
+package com.alfsuace.exaddfebrero.firestore.data
+
+import com.alfsuace.exaddfebrero.domain.Album
+import com.alfsuace.exaddfebrero.domain.AlbumRepository
+import com.alfsuace.exaddfebrero.firestore.data.remote.AlbumRemoteDataSource
+
+class AlbumDataRepositoryFirestore(private val albumRemoteDataSource: AlbumRemoteDataSource):AlbumRepository {
+    override suspend fun getAlbums(): List<Album> {
+        return albumRemoteDataSource.getAlbums()
+    }
+
+    override suspend fun getAlbumById(id: String): Album? {
+        return albumRemoteDataSource.getAlbumById(id)
+    }
+
+    override suspend fun saveAllAlbums(albums: List<Album>) {
+        albumRemoteDataSource.saveAllAlbums(albums)
+    }
+
+    override suspend fun saveAlbum(album: Album) {
+        albumRemoteDataSource.saveAlbum(album)
+    }
+
+    override suspend fun deleteAlbum(album: Album) {
+        albumRemoteDataSource.deleteAlbum(album)
+    }
+}

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/AlbumEntity.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/AlbumEntity.kt
@@ -1,0 +1,11 @@
+package com.alfsuace.exaddfebrero.firestore.data.remote
+
+import com.google.firebase.firestore.PropertyName
+
+
+data class AlbumEntity(
+    @get:PropertyName("id") @set:PropertyName("id") var id: String = "",
+    @get:PropertyName("name") @set:PropertyName("name") var name: String = "",
+    @get:PropertyName("shroom_available") @set:PropertyName("shroom_available") var shroomAvailable: List<String> = emptyList(),
+    @get:PropertyName("stickers") @set:PropertyName("stickers") var stickers: List<String> = emptyList()
+)

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/AlbumRemoteDataSource.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/AlbumRemoteDataSource.kt
@@ -1,0 +1,72 @@
+package com.alfsuace.exaddfebrero.firestore.data.remote
+
+import com.alfsuace.exaddfebrero.domain.Album
+import com.alfsuace.exaddfebrero.domain.Mushroom
+import com.alfsuace.exaddfebrero.domain.Sticker
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class AlbumRemoteDataSource(private val firestore: FirebaseFirestore) {
+
+    suspend fun getAlbums(): List<Album> {
+        val snapshot = firestore.collection("Album").get().await()
+
+        val albumEntityList = snapshot.documents.mapNotNull {
+            it.toObject(AlbumEntity::class.java)
+        }
+
+        return albumEntityList.map { albumEntity ->
+            val mushrooms = albumEntity.shroomAvailable.mapNotNull { getMushroom(it) }
+            val stickers = albumEntity.stickers.mapNotNull { getSticker(it) }
+
+            albumEntity.toModel(mushrooms, stickers)
+        }
+    }
+
+    suspend fun getAlbumById(id: String): Album? {
+        val snapshot = firestore.collection("Album").document(id).get().await()
+        val albumEntity = snapshot.toObject(AlbumEntity::class.java)
+
+        return albumEntity?.let {
+            val mushrooms = it.shroomAvailable.mapNotNull { mushroomId -> getMushroom(mushroomId) }
+            val stickers = it.stickers.mapNotNull { stickerId -> getSticker(stickerId) }
+            it.toModel(mushrooms, stickers)
+        }
+    }
+
+    suspend fun saveAllAlbums(albums: List<Album>) {
+        val albumCollection = firestore.collection("Album")
+
+        albums.forEach { album ->
+            val mushroomIds = album.shroomAvailable.map { it.id }
+            val stickerIds = album.stickers.map { it.id }
+            albumCollection.document(album.id).set(album.toEntity(stickerIds, mushroomIds)).await()
+        }
+    }
+
+
+    suspend fun saveAlbum(album: Album) {
+        val stickerIds = album.stickers.map { it.id }
+        val mushroomIds = album.shroomAvailable.map { it.id }
+
+        firestore.collection("Album").document(album.id).set(album.toEntity(stickerIds, mushroomIds)).await()
+    }
+
+    suspend fun deleteAlbum(album: Album) {
+        firestore.collection("Album").document(album.id).delete().await()
+    }
+
+    suspend fun getSticker(id: String): Sticker? {
+        val snapshot = firestore.collection("Sticker").document(id).get().await()
+        val stickerEntity = snapshot.toObject(StickerEntity::class.java)
+
+        return stickerEntity?.let { entity ->
+            getMushroom(entity.shroom)?.let { entity.toModel(it) }
+        }
+    }
+
+    suspend fun getMushroom(id: String): Mushroom? {
+        val snapshot = firestore.collection("Mushroom").document(id).get().await()
+        return snapshot.toObject(MushroomEntity::class.java)?.toModel()
+    }
+}

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/AlbumRemoteDataSource.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/AlbumRemoteDataSource.kt
@@ -48,8 +48,8 @@ class AlbumRemoteDataSource(private val firestore: FirebaseFirestore) {
     suspend fun saveAlbum(album: Album) {
         val stickerIds = album.stickers.map { it.id }
         val mushroomIds = album.shroomAvailable.map { it.id }
-
-        firestore.collection("Album").document(album.id).set(album.toEntity(stickerIds, mushroomIds)).await()
+        val albumEntity = album.toEntity(mushroomIds, stickerIds)
+        firestore.collection("Album").document(album.id).set(albumEntity).await()
     }
 
     suspend fun deleteAlbum(album: Album) {
@@ -69,4 +69,21 @@ class AlbumRemoteDataSource(private val firestore: FirebaseFirestore) {
         val snapshot = firestore.collection("Mushroom").document(id).get().await()
         return snapshot.toObject(MushroomEntity::class.java)?.toModel()
     }
+
+    suspend fun saveStickers(stickers: List<Sticker>) {
+        val stickerCollection = firestore.collection("Sticker")
+
+        stickers.forEach { sticker ->
+            stickerCollection.document(sticker.id).set(sticker.toEntity(sticker.shroom.id)).await()
+        }
+    }
+
+    suspend fun saveMushrooms(mushrooms: List<Mushroom>) {
+        val mushroomCollection = firestore.collection("Mushroom")
+
+        mushrooms.forEach { mushroom ->
+            mushroomCollection.document(mushroom.id).set(mushroom.toEntity()).await()
+        }
+    }
+
 }

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/Mapper.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/Mapper.kt
@@ -1,0 +1,63 @@
+package com.alfsuace.exaddfebrero.firestore.data.remote
+
+import com.alfsuace.exaddfebrero.domain.Album
+import com.alfsuace.exaddfebrero.domain.Mushroom
+import com.alfsuace.exaddfebrero.domain.Sticker
+
+fun Mushroom.toEntity():MushroomEntity{
+    return MushroomEntity(
+        this.id,
+        this.name,
+        this.family,
+        this.description
+    )
+}
+
+fun MushroomEntity.toModel():Mushroom{
+    return Mushroom(
+        this.id,
+        this.name,
+        this.family,
+        this.description
+    )
+}
+
+fun Sticker.toEntity(mushroomId: String):StickerEntity{
+    return StickerEntity(
+        this.id,
+        mushroomId,
+        this.photo,
+        this.latitude,
+        this.longitude,
+        this.dateTime
+    )
+}
+
+fun StickerEntity.toModel(mushroom: Mushroom):Sticker{
+    return Sticker(
+        this.id,
+        mushroom,
+        this.photo,
+        this.latitude,
+        this.longitude,
+        this.dateTime
+    )
+}
+
+fun Album.toEntity(shroomsId: List<String>, stickersId: List<String>):AlbumEntity{
+    return AlbumEntity(
+        this.id,
+        this.name,
+        shroomsId,
+        stickersId
+    )
+}
+
+fun AlbumEntity.toModel(shrooms: List<Mushroom>, stickers: List<Sticker>):Album{
+    return Album(
+        this.id,
+        this.name,
+        shrooms,
+        stickers
+    )
+}

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/MushroomEntity.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/MushroomEntity.kt
@@ -1,0 +1,10 @@
+package com.alfsuace.exaddfebrero.firestore.data.remote
+
+import com.google.firebase.firestore.PropertyName
+
+data class MushroomEntity(
+    @get:PropertyName("id") @set:PropertyName("id") var id: String = "",
+    @get:PropertyName("name") @set:PropertyName("name") var name: String = "",
+    @get:PropertyName("family") @set:PropertyName("family") var family: String = "",
+    @get:PropertyName("description") @set:PropertyName("description") var description: String = ""
+)

--- a/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/StickerEntity.kt
+++ b/app/src/main/java/com/alfsuace/exaddfebrero/firestore/data/remote/StickerEntity.kt
@@ -1,0 +1,12 @@
+package com.alfsuace.exaddfebrero.firestore.data.remote
+
+import com.google.firebase.firestore.PropertyName
+
+data class StickerEntity(
+    @get:PropertyName("id") @set:PropertyName("id") var id: String = "",
+    @get:PropertyName("shroom") @set:PropertyName("shroom") var shroom: String = "",
+    @get:PropertyName("photo") @set:PropertyName("photo") var photo: String = "",
+    @get:PropertyName("latitude") @set:PropertyName("latitude") var latitude: String = "",
+    @get:PropertyName("longitude") @set:PropertyName("longitude") var longitude: String = "",
+    @get:PropertyName("date_time") @set:PropertyName("date_time") var dateTime: String = ""
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.google) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.6.1"
+firebaseBom = "33.9.0"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -10,13 +11,15 @@ material = "1.12.0"
 activity = "1.10.0"
 constraintlayout = "2.2.0"
 
-
 gson = "2.12.1"
 room="2.6.1"
 ksp="2.0.21-1.0.27"
+google="4.4.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-firestore = { module = "com.google.firebase:firebase-firestore" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -33,4 +36,6 @@ room-ksp={group="androidx.room", name="room-compiler", version.ref="room"}
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp={id="com.google.devtools.ksp", version.ref="ksp"}
+google={id="com.google.gms.google-services", version.ref="google"}
+
 


### PR DESCRIPTION
Este ejercicio pide recuperar los albumes, con la informacion que tengan dentro, aparte del mock, nos pide crear un album, borrarlo, y ser capaces de eliminar un cromo a gusto del usuario.

El planteamiento de la dase de datos es guardar los ids en vez del objeto entero en firestore, y luego ir recuperando desde la capa de datos.

se añade la capa de datos remota (entitites, mapper y remotedatasource), testeo en main, y un providefirebase

![firestore funcionando](https://github.com/user-attachments/assets/5a486601-d43a-42b3-9be3-5252f8c166a2)
